### PR TITLE
Fix `gtkhash -C` error handling

### DIFF
--- a/src/check.c
+++ b/src/check.c
@@ -215,7 +215,7 @@ GSList *check_file_load(GSList *ud_list, GFile *file)
 	if (!fis) {
 		check_file_error(file, error);
 		g_error_free(error);
-		return NULL;
+		return ud_list;
 	}
 
 	GDataInputStream *dis = g_data_input_stream_new((GInputStream *)fis);


### PR DESCRIPTION
Don't lose the whole list when failing to read a file.